### PR TITLE
Fix extensible size constraint PER encoding

### DIFF
--- a/libasn1fix/asn1fix_constraint.c
+++ b/libasn1fix/asn1fix_constraint.c
@@ -232,6 +232,32 @@ asn1constraint_resolve(arg_t *arg, asn1p_constraint_t *ct, asn1p_expr_type_e ety
     return rvalue;
 }
 
+void
+asn1constraint_remove_after_extension_marker(asn1p_constraint_t* ct) {
+    unsigned int i;
+
+    if(!ct) return;
+
+    for(i = 0; i < ct->el_count; i++) {
+        if(ct->elements[i]->type == ACT_EL_EXT)
+            break;
+        asn1constraint_remove_after_extension_marker(ct->elements[i]);
+    }
+
+    /* Keep the extensibility mark */
+    i++;
+
+    /* Remove elements after the extensibility mark. */
+    for(; i < ct->el_count; ct->el_count--) {
+        asn1p_constraint_t *rm = ct->elements[ct->el_count - 1];
+        asn1p_constraint_free(rm);
+    }
+
+    if(i < ct->el_size)
+        ct->elements[i] = 0;
+
+}
+
 static void
 _remove_extensions(arg_t *arg, asn1p_constraint_t *ct, int forgive_last) {
 	unsigned int i;

--- a/libasn1fix/asn1fix_constraint.h
+++ b/libasn1fix/asn1fix_constraint.h
@@ -17,4 +17,12 @@ int asn1constraint_resolve(
  */
 int asn1constraint_pullup(arg_t *arg);
 
+/*
+ * Modifies a constraint data structure, removing everything after the extension
+ * marker, but keeping the extension marker.
+ * For use for PER range computation.
+ */
+void
+asn1constraint_remove_after_extension_marker(asn1p_constraint_t* ct);
+
 #endif	/* ASN1FIX_CONSTRAINT_H */

--- a/libasn1fix/asn1fix_crange.c
+++ b/libasn1fix/asn1fix_crange.c
@@ -825,7 +825,86 @@ asn1cnst_range_t *
 asn1constraint_compute_PER_range(const char *dbg_name, asn1p_expr_type_e expr_type, const asn1p_constraint_t *ct, enum asn1p_constraint_type_e requested_ct_type, const asn1cnst_range_t *minmax, int *exmet, enum cpr_flags cpr_flags) {
     if(0) return asn1constraint_compute_constraint_range(dbg_name, expr_type, ct, requested_ct_type, minmax, exmet, cpr_flags | CPR_strict_PER_visibility);
     /* Due to peculiarities of PER constraint handling, we don't enable strict PER visibility upfront here. */
-    return asn1constraint_compute_constraint_range(dbg_name, expr_type, ct, requested_ct_type, minmax, exmet, cpr_flags);
+
+    //
+    // If this is a PER-visible size constraint for a type that it may apply to, remove everything after the extension
+    // marker for purposes of calculating the range for PER encoding.
+    //
+    // See:
+    //
+    // ITU-T Rec. X.691 (02/2021);
+    // "PER-visible constraints", sec 10.39 says:
+    //
+    //     "Subject to the above, all size constraints are PER-visible."
+    //
+    // However, this is a little too general since the following sections on encoding specific types with size
+    // constraints state that extensions to PER-visible size constraints are not used in calculating ranges and length
+    // determinants for PER encodings.  i.e. Size EXTENSIONS are effectively NOT PER-visible.
+    //
+    // "Encoding the bitstring type", sec 16.6 says:
+    //
+    //     "If the type is extensible for PER encodings (see 10.3.9), then a bit-field consisting of a single bit shall
+    //     be added to the field-list. The bit shall be set to 1 if the length of this encoding is not within the range
+    //     of the extension root, and zero otherwise. In the former case, 16.11 shall be invoked to add the length as a
+    //     semi-constrained whole number to the field-list, followed by the bitstring value. In the latter case the
+    //     length and value shall be encoded as if no extension is present in the constraint."
+    //
+    // In other words:
+    //   * The range of the extension root must be known.
+    //   * Any extensions added to the size constraint shouldn't be used to calculate that range, and
+    //   * If the size of a value is outside the extension root then the range isn't used and the length determinant is
+    //     calculated as if the upper bound were unconstrained.
+    //
+    // See also X.691:
+    //
+    // Sec. 17.6 (Encoding the octetstring type)
+    // Sec. 20.4 (Encoding the sequence-of type)
+    // Sec. 30.4 (Encoding the restricted character string types)
+    //
+    // which have similar language, and:
+    //
+    // X.691 sec 22.2 (Encoding the set-of types)
+    //
+    // which says that set-of types are encoded the same as sequence-of types.
+    //
+    // See also: ITU-T Rec. X.680 (02/2021), 51.5.2 which specifies that size constraints can only be applied to the
+    // following types:
+    //   * bit string
+    //   * octet string
+    //   * character string
+    //   * set-of
+    //   * sequence-of
+    //
+    // And: X.691 10.3.7: only known multiplier char types have PER visible constraints.
+    //
+    const int size_constraint_can_apply = (
+        expr_type == ASN_BASIC_BIT_STRING
+        || expr_type == ASN_BASIC_OCTET_STRING
+        || (expr_type & ASN_STRING_KM_MASK) != 0
+        || expr_type == ASN_CONSTR_SET_OF
+        || expr_type == ASN_CONSTR_SEQUENCE_OF);
+
+    asn1cnst_range_t *range;
+
+    if (ct && size_constraint_can_apply && requested_ct_type == ACT_CT_SIZE) {
+
+        // Clone the constraint locally to do this, so computations for other encodings using it aren't affected
+        asn1p_constraint_t *ct_no_size_extensions
+            = asn1p_constraint_clone((asn1p_constraint_t *)ct); // Cast to non-const to avoid warning
+
+        asn1constraint_remove_after_extension_marker(ct_no_size_extensions);
+
+        range = asn1constraint_compute_constraint_range(dbg_name, expr_type, ct_no_size_extensions, requested_ct_type,
+            minmax, exmet, cpr_flags);
+
+        asn1p_constraint_free(ct_no_size_extensions);
+    } else {
+        // The normal case: not a size constraint
+        range = asn1constraint_compute_constraint_range(dbg_name, expr_type, ct, requested_ct_type, minmax, exmet,
+            cpr_flags);
+    }
+
+    return range;
 }
 
 static asn1cnst_range_t *

--- a/libasn1fix/asn1fix_crange.c
+++ b/libasn1fix/asn1fix_crange.c
@@ -827,8 +827,9 @@ asn1constraint_compute_PER_range(const char *dbg_name, asn1p_expr_type_e expr_ty
     /* Due to peculiarities of PER constraint handling, we don't enable strict PER visibility upfront here. */
 
     //
-    // If this is a PER-visible size constraint for a type that it may apply to, remove everything after the extension
-    // marker for purposes of calculating the range for PER encoding.
+    // If this is a PER-visible size constraint for a type that it may apply to,
+    // remove everything after the extension marker for purposes of calculating
+    // the range for PER encoding.
     //
     // See:
     //
@@ -837,23 +838,30 @@ asn1constraint_compute_PER_range(const char *dbg_name, asn1p_expr_type_e expr_ty
     //
     //     "Subject to the above, all size constraints are PER-visible."
     //
-    // However, this is a little too general since the following sections on encoding specific types with size
-    // constraints state that extensions to PER-visible size constraints are not used in calculating ranges and length
-    // determinants for PER encodings.  i.e. Size EXTENSIONS are effectively NOT PER-visible.
+    // However, this is a little too general since the following sections on
+    // encoding specific types with size constraints state that extensions to
+    // PER-visible size constraints are not used in calculating ranges and
+    // length determinants for PER encodings.  i.e. Size EXTENSIONS are
+    // effectively NOT PER-visible.
     //
     // "Encoding the bitstring type", sec 16.6 says:
     //
-    //     "If the type is extensible for PER encodings (see 10.3.9), then a bit-field consisting of a single bit shall
-    //     be added to the field-list. The bit shall be set to 1 if the length of this encoding is not within the range
-    //     of the extension root, and zero otherwise. In the former case, 16.11 shall be invoked to add the length as a
-    //     semi-constrained whole number to the field-list, followed by the bitstring value. In the latter case the
-    //     length and value shall be encoded as if no extension is present in the constraint."
+    //     "If the type is extensible for PER encodings (see 10.3.9), then a
+    //     bit-field consisting of a single bit shall be added to the
+    //     field-list. The bit shall be set to 1 if the length of this encoding
+    //     is not within the range of the extension root, and zero otherwise. In
+    //     the former case, 16.11 shall be invoked to add the length as a
+    //     semi-constrained whole number to the field-list, followed by the
+    //     bitstring value. In the latter case the length and value shall be
+    //     encoded as if no extension is present in the constraint."
     //
     // In other words:
     //   * The range of the extension root must be known.
-    //   * Any extensions added to the size constraint shouldn't be used to calculate that range, and
-    //   * If the size of a value is outside the extension root then the range isn't used and the length determinant is
-    //     calculated as if the upper bound were unconstrained.
+    //   * Any extensions added to the size constraint shouldn't be used to
+    //     calculate that range, and
+    //   * If the size of a value is outside the extension root then the range
+    //     isn't used and the length determinant is calculated as if there were
+    //     no constraint.
     //
     // See also X.691:
     //
@@ -867,15 +875,16 @@ asn1constraint_compute_PER_range(const char *dbg_name, asn1p_expr_type_e expr_ty
     //
     // which says that set-of types are encoded the same as sequence-of types.
     //
-    // See also: ITU-T Rec. X.680 (02/2021), 51.5.2 which specifies that size constraints can only be applied to the
-    // following types:
+    // See also: ITU-T Rec. X.680 (02/2021), 51.5.2 which specifies that size
+    // constraints can only be applied to the following types:
     //   * bit string
     //   * octet string
     //   * character string
     //   * set-of
     //   * sequence-of
     //
-    // And: X.691 10.3.7: only known multiplier char types have PER visible constraints.
+    // And: X.691 10.3.7: only known multiplier char types have PER visible
+    // constraints.
     //
     const int size_constraint_can_apply = (
         expr_type == ASN_BASIC_BIT_STRING
@@ -888,20 +897,21 @@ asn1constraint_compute_PER_range(const char *dbg_name, asn1p_expr_type_e expr_ty
 
     if (ct && size_constraint_can_apply && requested_ct_type == ACT_CT_SIZE) {
 
-        // Clone the constraint locally to do this, so computations for other encodings using it aren't affected
+        // Clone the constraint locally to do this, so computations for other
+        // encodings using it aren't affected
         asn1p_constraint_t *ct_no_size_extensions
-            = asn1p_constraint_clone((asn1p_constraint_t *)ct); // Cast to non-const to avoid warning
+        = asn1p_constraint_clone((asn1p_constraint_t *)ct); // Cast to non-const
 
         asn1constraint_remove_after_extension_marker(ct_no_size_extensions);
 
-        range = asn1constraint_compute_constraint_range(dbg_name, expr_type, ct_no_size_extensions, requested_ct_type,
-            minmax, exmet, cpr_flags);
+        range = asn1constraint_compute_constraint_range(dbg_name, expr_type,
+           ct_no_size_extensions, requested_ct_type, minmax, exmet, cpr_flags);
 
         asn1p_constraint_free(ct_no_size_extensions);
     } else {
         // The normal case: not a size constraint
-        range = asn1constraint_compute_constraint_range(dbg_name, expr_type, ct, requested_ct_type, minmax, exmet,
-            cpr_flags);
+        range = asn1constraint_compute_constraint_range(dbg_name, expr_type, ct,
+           requested_ct_type, minmax, exmet, cpr_flags);
     }
 
     return range;


### PR DESCRIPTION
# PR Details
## Description

Fixes the as1c compiler's code generation for PER ranges derived from extensible size constraints.

The asn1c represents size constraints as a syntax tree of `asn1p_constraint_t` structs that contains all the elements parsed from a constraint.   For example, the SIZE constraint:

```asn1
(SIZE(13, ..., 14))
```

is represented as a tree of `asn1p_constraint_t` structs like:

* SET
  * SizeConstraint
    * SET
      * CSV
        * SingleValue (13)
        * ExtensionMarker (...)
        * SingleValue (14)

The functions in `asn1fix_crange.c` convert the `asn1p_constraint_t` struct into an `asn1cnst_range_t` struct to represent the range needed for different encodings.  The function `asn1constraint_compute_PER_range` computes the range for PER encodings, which are used to determine the number of bits needed to represent length determinants for sizes within the extension root.  Currently the above size constraint results in a `asn1cnst_range_t` struct like:

* left.value: 13
* right.value: 14
* extensible: true

The `emit_single_member_PER_constraint` method in `asn1c_C.c` uses the range struct to generate the following code that includes the number of bits to encode length determinants for the type in (struct field names added for clarity):  

```c
{ 
    flags=APC_CONSTRAINED | APC_EXTENSIBLE,  
    range_bits=1,  
    effective_bits=1,  
    lower_bound=13,  
    upper_bound=14
 }
```

This is incorrect.  The extension shouldn't be included in the range calculation, and the "range_bits" and "effective_bits" should be 0.  (See below for the rationale for saying this is incorrect).

This PR fixes the issue by adding code to the `asn1constraint_compute_PER_range` that makes a clone of the `asn1p_constraint_t` to use for the PER computation, and recursively removes elements after any extension markers.  In the example, this transforms the constraint tree to:

* SET
  * SizeConstraint
    * SET
      * CSV
        * SingleValue (13)
        * ExtensionMarker (...)
     
which then produces a `asn1cnst_range_t` struct like:

* left.value: 13
* right.value:  13
* extensible: true

resulting in the correct code generated in the type (struct field names added for clarity):

```c
{ 
    flags=APC_CONSTRAINED | APC_EXTENSIBLE,  
    range_bits=0,  
    effective_bits=0,  
    lower_bound=13,  
    upper_bound=13
 }
```

## Related GitHub Issue

[Incorrect UPER encoding/decoding of BIT STRING types with extensions #2](https://github.com/usdot-fhwa-stol/usdot-asn1c/issues/2)

## Related Jira Key

N/A

## Motivation and Context

The latest version of the J2735 specification (2024) added a "Jackknife" event to the "VehicleEventFlags" bitstring with an accompanying extension to the SIZE constraint on the bitstring.  The code generated by the current version of asn1c does not handle that case correctly, and resulted in an UPER codec that broke backwards compatibility with previous versions of the standard, and with codecs produced by other ASN.1 compilers.  

We worked around the issue by manually editing the generated code as described here:

[CDOT-CV/asn1_codec:  Workaround bsm vehicle event flags issue #37 ](https://github.com/CDOT-CV/asn1_codec/pull/37)
[CDOT-CV/asn1_codec: Fix VehicleEventFlags Jackknife Event Extension #42 ](https://github.com/CDOT-CV/asn1_codec/pull/42)

However it would be desirable to fix the code generated by the compiler so that the manual edits won't be necessary in the future.

## References and Discussion

Rationale for why size extensions shouldn't be used in the PER range calculation:

In practice, not including the extensions in the range calculations ensures that UPER encodings are backward and forward compatible when new versions of the specification are issued.  This is supported by the ASN.1 specifications, although this particular point is not very clearly expressed in the recommendation documents.

See:

ITU-T Rec. X.691 (02/2021), "PER-visible constraints", sec 10.39 says:

>"Subject to the above, all size constraints are PER-visible."

However, this is a little too general since the following sections on encoding specific types with size constraints state that extensions to PER-visible size constraints are not used in calculating ranges and length determinants for PER encodings.  i.e. Size EXTENSIONS are effectively NOT PER-visible.

"Encoding the bitstring type", sec 16.6 says:

>"If the type is extensible for PER encodings (see 10.3.9), then a bit-field consisting of a single bit shall be added to the field-list. The bit shall be set to 1 if the length of this encoding is not within the range of the extension root, and zero otherwise. In the former case, 16.11 shall be invoked to add the length as a semi-constrained whole number to the field-list, followed by the bitstring value. In the latter case the length and value shall be encoded as if no extension is present in the constraint."

In other words:
  * The range of the extension root must be known.
  * Any extensions added to the size constraint shouldn't be used to calculate that range, and
  * If the size of a value is outside the extension root then the range isn't used and the length determinant is calculated as if the size were unconstrained (as a "semi-constrained [i.e. positive] whole number")

See also X.691:

Sec. 17.6 (Encoding the octetstring type)
Sec. 20.4 (Encoding the sequence-of type)
Sec. 30.4 (Encoding the restricted character string types)

which have similar language, and:

X.691 sec 22.2 (Encoding the set-of types)

which says that set-of types are encoded the same as sequence-of types.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The fix was tested by installing the compiler as described below and compiling the following asn1:

```asn1
TheModule
DEFINITIONS AUTOMATIC TAGS ::=
BEGIN

Bitstring           ::= BIT STRING { f0 (0), f1 (1), f2 (2) } (SIZE (3, ...))
BitstringWithExt    ::= BIT STRING { f0 (0), f1 (1), f2 (2), f3 (3) } (SIZE (3, ..., 4))
OctetString         ::= OCTET STRING (SIZE (1..5, ...))
OctetStringWithExt  ::= OCTET STRING (SIZE (1..5, ..., 6..10))
Str                 ::= IA5String (SIZE(5, ...))
StrWithExt          ::= IA5String (SIZE(5, ..., 6))
SeqOf               ::= SEQUENCE (SIZE(1..2, ...)) OF BOOLEAN
SeqOfWithExt        ::= SEQUENCE (SIZE(1..2, ..., 3)) OF BOOLEAN
SetOf               ::= SET (SIZE(1..2, ...)) OF BOOLEAN
SetOfWithExt        ::= SET (SIZE(1..2, ..., 3)) OF BOOLEAN

END
```

Then building the `converter-example` executable and using it to verify the types with and without extensions produce the same UPER for values with sizes in the root or outside of the root.  

For example for the `Bitstring` and `BitstringWithExt` types, the XER:

```xml
<Bitstring>1111</Bitstring>
```
and
```xml
<BitstringWithExt>1111</BitstringWithExt>
```

produce the same UPER hex value:

```
8278 = 8278
```

whereas before applying the fix, the codec produces different (incorrect) UPER for the `BitstringWithExt` type:

```
8278 != 7c
```

Also the `usdot-asn1c` submodule in the asn1_codec app was updated with this PR, and used to regenerate the codec from the J2735/2024 asn1 files and run in Docker, and it was verified all all the tests related to the VehicleEventFlags type in that app still pass, see:
https://github.com/iyourshaw/asn1_codec/blob/asn1c-ext-size-fix/src/tests.cpp#L268

### Unit tests

Verified that all the existing tests pass before and after the change.

Tests run via:
```bash
make check
```

### Test environment: 

* Ubuntu 24.04 (run via WSL within Windows 11)
* Installed via apt:
  * automake
  * libtool
  * bison
  * flex
  * clang
* C compiler: Ubuntu clang version 18.1.3

Compiled and installed via:
```bash
export CC=/usr/bin/clang
export CFLAGS="-std=gnu99"
test -f configure || autoreconf -iv
./configure
make
make install
```


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
