### PR TITLE
modify choice print constr to print name

### DIFF
--- a/skeletons/constr_CHOICE_print.c
+++ b/skeletons/constr_CHOICE_print.c
@@ -34,7 +34,7 @@ CHOICE_print(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         }
 
         /* Print member's name and stuff */
-        if(0) {
+        if(1) {
             if(cb(elm->name, strlen(elm->name), app_key) < 0
             || cb(": ", 2, app_key) < 0)
                 return -1;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Enabled the CHOICE member-name label in asn1c's text printer (if(0)→if(1) in CHOICE_print). Decoded CHOICE fields now show which alternative was selected, e.g. laneType: vehicle: 00 instead of just laneType: 00. Print-only change; decoding behavior is unchanged.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

https://usdot-carma.atlassian.net/browse/CVCS-174

## Motivation and Context

By default, asn1c's plain-text printer (asn_fprint) prints only the value of the selected alternative and leaves out its name. That's why the decoded output showed laneType: 00. The 00 is the value, but there was no way to tell it was the vehicle alternative.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
