### PR TITLE
Revert "modify choice print constr to print name"

### DIFF
--- a/skeletons/constr_CHOICE_print.c
+++ b/skeletons/constr_CHOICE_print.c
@@ -34,7 +34,7 @@ CHOICE_print(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         }
 
         /* Print member's name and stuff */
-        if(1) {
+        if(0) {
             if(cb(elm->name, strlen(elm->name), app_key) < 0
             || cb(": ", 2, app_key) < 0)
                 return -1;


### PR DESCRIPTION
Reverts usdot-fhwa-stol/usdot-asn1c#11 which was suppose to be one develop