### PR TITLE
CVCS 188 - Added failed type variable to the decode rval

### DIFF
--- a/skeletons/ANY_uper.c
+++ b/skeletons/ANY_uper.c
@@ -13,6 +13,8 @@
         asn_dec_rval_t tmprval;             \
         tmprval.code = _code;               \
         tmprval.consumed = consumed_myself; \
+        tmprval.failed_type =               \
+            (_code == RC_OK) ? NULL : (td ? td->name : NULL); \
         return tmprval;                     \
     } while(0)
 

--- a/skeletons/BIT_STRING_uper.c
+++ b/skeletons/BIT_STRING_uper.c
@@ -12,6 +12,8 @@
         asn_dec_rval_t tmprval;             \
         tmprval.code = _code;               \
         tmprval.consumed = consumed_myself; \
+        tmprval.failed_type =               \
+            (_code == RC_OK) ? NULL : (td ? td->name : NULL); \
         return tmprval;                     \
     } while(0)
 

--- a/skeletons/ENUMERATED_uper.c
+++ b/skeletons/ENUMERATED_uper.c
@@ -27,6 +27,7 @@ ENUMERATED_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
     if(rval.code == RC_OK) {
         if(asn_long2INTEGER(st, value)) {
             rval.code = RC_FAIL;
+            rval.failed_type = td->name;
         }
     }
     return rval;

--- a/skeletons/NativeInteger_uper.c
+++ b/skeletons/NativeInteger_uper.c
@@ -32,9 +32,10 @@ NativeInteger_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
     if(rval.code == RC_OK) {
         if((specs&&specs->field_unsigned)
             ? asn_INTEGER2ulong(&tmpint, (unsigned long *)native)
-            : asn_INTEGER2long(&tmpint, native))
+            : asn_INTEGER2long(&tmpint, native)) {
             rval.code = RC_FAIL;
-        else
+            rval.failed_type = td->name;
+        } else
             ASN_DEBUG("NativeInteger %s got value %ld",
                       td->name, *native);
     }

--- a/skeletons/OCTET_STRING_uper.c
+++ b/skeletons/OCTET_STRING_uper.c
@@ -12,6 +12,8 @@
         asn_dec_rval_t tmprval;\
         tmprval.code = _code;\
         tmprval.consumed = consumed_myself;\
+        tmprval.failed_type =\
+            (_code == RC_OK) ? NULL : (td ? td->name : NULL);\
         return tmprval;\
     } while(0)
 

--- a/skeletons/asn_codecs.h
+++ b/skeletons/asn_codecs.h
@@ -86,11 +86,13 @@ enum asn_dec_rval_code_e {
 typedef struct asn_dec_rval_s {
 	enum asn_dec_rval_code_e code;	/* Result code */
 	size_t consumed;		/* Number of bytes consumed */
+	const char *failed_type;	/* ASN.1 type name at point of failure, or NULL */
 } asn_dec_rval_t;
 #define	ASN__DECODE_FAILED do {					\
 	asn_dec_rval_t tmp_error;				\
 	tmp_error.code = RC_FAIL;				\
 	tmp_error.consumed = 0;					\
+	tmp_error.failed_type = td ? td->name : NULL;		\
 	ASN_DEBUG("Failed to decode element %s", td ? td->name : "");	\
 	return tmp_error;					\
 } while(0)
@@ -98,6 +100,7 @@ typedef struct asn_dec_rval_s {
 	asn_dec_rval_t tmp_error;				\
 	tmp_error.code = RC_WMORE;				\
 	tmp_error.consumed = 0;					\
+	tmp_error.failed_type = td ? td->name : NULL;		\
 	return tmp_error;					\
 } while(0)
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
In this PR
- Added failed_type to decode result struct
- Updated it in ASN__DECODE_FAILED/ASN__DECODE_STARVED, and in the manual decode-result paths of NativeInteger_uper.c, ENUMERATED_uper.c, ANY_uper.c, BIT_STRING_uper.c, and OCTET_STRING_uper.c  where these bypass the shared macros and build their own asn_dec_rval_t, so the macro fix alone doesn't reach them.
- Fixed a corrupted line in ASN__DECODE_STARVED that broke compilation
- Investigated all asn_dec_rval_t/.failed_type usage in V2X Hub and v2x-ros-conversion repos
- Confirmed all decode calls only read .code/.consumed; 
- The .failed_type->name hits found belong to the separate, pre-existing asn_enc_rval_t (encode path), unaffected by this change

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
[CVCS-188](https://usdot-carma.atlassian.net/browse/CVCS-188)
<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CVCS-188]: https://usdot-carma.atlassian.net/browse/CVCS-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ